### PR TITLE
feat: Adding Chart Version to Deployment template

### DIFF
--- a/charts/charts/templates/deployment.yaml
+++ b/charts/charts/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: VERSION
+          value: {{ .Chart.Version }}
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
           value: {{ quote $pval }}


### PR DESCRIPTION
This will allow applications to just consume an ENV variable called VERSION to understand which version is running from within the app. 