### PR TITLE
chore(fix): Updating Knative Service Definition

### DIFF
--- a/charts/charts/templates/ksvc.yaml
+++ b/charts/charts/templates/ksvc.yaml
@@ -1,41 +1,42 @@
 {{- if .Values.knativeDeploy }}
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-{{- if .Values.service.name }}
+  {{- if .Values.service.name }}
   name: {{ .Values.service.name }}
-{{- else }}
+  {{- else }}
   name: {{ template "fullname" . }}
-{{- end }}
+  {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-            env:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+    spec:
+      containers:
+        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
 {{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
+          - name: {{ $pkey }}
+            value: {{ quote $pval }}
 {{- end }}
-            livenessProbe:
-              httpGet:
-                path: {{ .Values.probePath }}
-              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-              successThreshold: {{ .Values.livenessProbe.successThreshold }}
-              timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            readinessProbe:
-              failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-              httpGet:
-                path: {{ .Values.probePath }}
-              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-              successThreshold: {{ .Values.readinessProbe.successThreshold }}
-              timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            resources:
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probePath }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.probePath }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          resources:
 {{ toYaml .Values.resources | indent 14 }}
 {{- end }}


### PR DESCRIPTION
This updated uses the v1 Service API and it also includes the `minScale` option as some people might want to always have at least 1 instance of the service.